### PR TITLE
implement CAR-58: define canonical ditto_core JSON schema & generate …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,8 @@ Thumbs.db
 *.db-*
 .env
 .mcp.json
+
+# ============================================================
+# Generated TypeScript types (re-generate with: make generate-types)
+# ============================================================
+frontend/src/lib/types/ditto.generated.ts

--- a/ditto_engine/Cargo.lock
+++ b/ditto_engine/Cargo.lock
@@ -20,6 +20,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
+ "ts-rs",
 ]
 
 [[package]]
@@ -214,6 +215,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ts-rs"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756050066659291d47a554a9f558125db17428b073c5ffce1daf5dcb0f7231d8"
+dependencies = [
+ "thiserror",
+ "ts-rs-macros",
+]
+
+[[package]]
+name = "ts-rs-macros"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d90eea51bc7988ef9e674bf80a85ba6804739e535e9cab48e4bb34a8b652aa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "termcolor",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,10 +317,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "zmij"

--- a/ditto_engine/ditto_core/Cargo.toml
+++ b/ditto_engine/ditto_core/Cargo.toml
@@ -6,3 +6,7 @@ edition = "2024"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+ts-rs = { version = "12", optional = true }
+
+[features]
+ts = ["ts-rs"]

--- a/ditto_engine/ditto_core/src/lib.rs
+++ b/ditto_engine/ditto_core/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod engine;
 pub mod state;
+#[cfg(feature = "ts")]
+pub mod schema;
 
 pub use engine::validate_action;
 pub use state::{

--- a/ditto_engine/ditto_core/src/schema.rs
+++ b/ditto_engine/ditto_core/src/schema.rs
@@ -1,0 +1,37 @@
+// ditto_core schema v0.1.0
+//
+// Single canonical source of truth for all types exchanged between the
+// ditto_core engine and the SvelteKit frontend.
+//
+// Generated output: frontend/src/lib/types/ditto.generated.ts
+// Re-generate:      make generate-types
+// Source structs:   ditto_engine/ditto_core/src/state.rs
+
+#[cfg(feature = "ts")]
+pub fn generate_typescript() -> String {
+    use crate::state::*;
+    use ts_rs::{Config, TS};
+
+    let cfg = Config::default();
+    let header = "// ditto_core schema v0.1.0\n\
+                  // AUTO-GENERATED — do not edit manually.\n\
+                  // Re-generate: make generate-types\n\
+                  // Source: ditto_engine/ditto_core/src/state.rs\n";
+
+    let decls = [
+        StackOrder::decl(&cfg),
+        Visibility::decl(&cfg),
+        StateCheck::decl(&cfg),
+        Condition::decl(&cfg),
+        Ability::decl(&cfg),
+        Action::decl(&cfg),
+        Animation::decl(&cfg),
+        Entity::decl(&cfg),
+        Zone::decl(&cfg),
+        Event::decl(&cfg),
+        GameState::decl(&cfg),
+    ]
+    .map(|d| format!("export {d}"));
+
+    format!("{}\n{}\n", header, decls.join("\n\n"))
+}

--- a/ditto_engine/ditto_core/src/state.rs
+++ b/ditto_engine/ditto_core/src/state.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
 
+#[cfg(feature = "ts")]
+use ts_rs::TS;
+
 // ==========================================
 // 1. THE GAME STATE
 // ==========================================
@@ -11,6 +14,7 @@ use std::collections::{HashMap, VecDeque};
 ///   where actions resolve in the order they were queued.
 /// - `Lifo`: last-in, first-out (a stack) — suited for games like MTG where the
 ///   most recently added spell or ability resolves first.
+#[cfg_attr(feature = "ts", derive(TS))]
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Default)]
 pub enum StackOrder {
     #[default]
@@ -20,6 +24,7 @@ pub enum StackOrder {
 
 /// The master struct. This is the exact payload that Elixir stores in memory
 /// and Svelte receives over WebSockets.
+#[cfg_attr(feature = "ts", derive(TS))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GameState {
     /// Every card, player, and token in the game, indexed by a unique UUID.
@@ -29,6 +34,7 @@ pub struct GameState {
     pub zones: HashMap<String, Zone>,
 
     /// The chronological list of events waiting to be executed.
+    #[cfg_attr(feature = "ts", ts(as = "Vec<Event>"))]
     pub event_queue: VecDeque<Event>,
 
     /// A log of visual updates for Svelte to animate (e.g., "-3 Health").
@@ -81,6 +87,7 @@ impl Default for GameState {
 /// A completely abstract object. It has no hardcoded rules.
 /// If it's a Magic card, it might have {"mana_cost": 3}.
 /// If it's a Pokémon, it might have {"hp": 120}.
+#[cfg_attr(feature = "ts", derive(TS))]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Entity {
     pub id: String,
@@ -96,6 +103,7 @@ pub struct Entity {
 }
 
 /// A container for entities.
+#[cfg_attr(feature = "ts", derive(TS))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Zone {
     pub id: String,
@@ -108,6 +116,7 @@ pub struct Zone {
     pub entities: Vec<String>,
 }
 
+#[cfg_attr(feature = "ts", derive(TS))]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Visibility {
     Public,          // Everyone sees the cards (e.g., The Board)
@@ -127,6 +136,7 @@ pub enum Visibility {
 ///
 /// Example — MTG:  `{ watch_property: "toughness", operator: "<=", threshold: 0, move_to_zone: "graveyard" }`
 /// Example — Pokémon: `{ watch_property: "hp", operator: "<=", threshold: 0, move_to_zone: "discard_pile" }`
+#[cfg_attr(feature = "ts", derive(TS))]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StateCheck {
     /// The entity property to inspect (e.g. `"health"`, `"toughness"`).
@@ -144,6 +154,7 @@ pub struct StateCheck {
 // ==========================================
 
 /// The Event-Condition-Action definition built by the designer in Svelte.
+#[cfg_attr(feature = "ts", derive(TS))]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Ability {
     pub id: String,
@@ -159,6 +170,7 @@ pub struct Ability {
     pub cancels: bool,
 }
 
+#[cfg_attr(feature = "ts", derive(TS))]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Condition {
     pub target: String,
@@ -172,6 +184,7 @@ pub struct Condition {
 // ==========================================
 
 /// The wrapper that gives context to an action waiting in the queue.
+#[cfg_attr(feature = "ts", derive(TS))]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Event {
     pub source_id: String,
@@ -180,6 +193,7 @@ pub struct Event {
 
 /// The ONLY ways the game state is allowed to change.
 /// By restricting mutations to these enums, the engine remains perfectly predictable.
+#[cfg_attr(feature = "ts", derive(TS))]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Action {
     MutateProperty {
@@ -205,6 +219,7 @@ pub enum Action {
 // ==========================================
 
 /// Instructions sent back to Svelte to make the game look good.
+#[cfg_attr(feature = "ts", derive(TS))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Animation {
     FloatText {
@@ -225,6 +240,23 @@ pub enum Animation {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn assert_serde<T: serde::Serialize + serde::de::DeserializeOwned>() {}
+
+    #[test]
+    fn all_types_implement_serde_roundtrip_bounds() {
+        assert_serde::<GameState>();
+        assert_serde::<Entity>();
+        assert_serde::<Zone>();
+        assert_serde::<Action>();
+        assert_serde::<Animation>();
+        assert_serde::<Ability>();
+        assert_serde::<Event>();
+        assert_serde::<Condition>();
+        assert_serde::<StateCheck>();
+        assert_serde::<Visibility>();
+        assert_serde::<StackOrder>();
+    }
 
     fn make_entity(id: &str, props: Vec<(&str, i32)>) -> Entity {
         Entity {

--- a/ditto_engine/ditto_core/tests/export_types.rs
+++ b/ditto_engine/ditto_core/tests/export_types.rs
@@ -1,0 +1,18 @@
+#![cfg(feature = "ts")]
+
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn export_all_types() {
+    let content = ditto_core::schema::generate_typescript();
+
+    let out_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../frontend/src/lib/types/ditto.generated.ts");
+
+    if let Some(parent) = out_path.parent() {
+        fs::create_dir_all(parent).expect("failed to create types dir");
+    }
+
+    fs::write(&out_path, content).expect("failed to write ditto.generated.ts");
+}

--- a/makefile
+++ b/makefile
@@ -1,12 +1,16 @@
-.PHONY: setup dev dev-backend dev-frontend build-wasm
+.PHONY: setup dev dev-backend dev-frontend build-wasm generate-types
 
 setup:
 	$(MAKE) build-wasm
+	$(MAKE) generate-types
 	cd backend && mix deps.get
 	cd frontend && pnpm i
 
 build-wasm:
 	cd ditto_engine/ditto_wasm && wasm-pack build --target web
+
+generate-types:
+	cd ditto_engine && cargo test -p ditto_core --features ts --test export_types
 
 dev-backend:
 	cd backend && mix phx.server
@@ -14,5 +18,5 @@ dev-backend:
 dev-frontend:
 	cd frontend && pnpm run dev --open
 
-dev:
+dev: generate-types
 	$(MAKE) -j2 dev-backend dev-frontend


### PR DESCRIPTION
…TypeScript types

- Add ts-rs v12 as optional dep behind a `ts` feature flag in ditto_core
- Derive TS on all 11 public types in state.rs (feature-gated, zero impact on ditto_nif / ditto_wasm which depend on ditto_core without the feature)
- Add #[ts(as = "Vec<Event>")] on event_queue to work around VecDeque lacking TS impl
- Add schema.rs with generate_typescript() that emits all type decls with export prefix
- Add tests/export_types.rs integration test that writes ditto.generated.ts
- Add `make generate-types` target (cd ditto_engine && cargo test --features ts)
- Wire generate-types into `make setup` and `make dev`
- Gitignore frontend/src/lib/types/ditto.generated.ts (regenerated on every boot)
- Add serde roundtrip bounds compile-time test for all 11 types