### PR TITLE
Claude/fix pr 119 conflicts vk d ep

### DIFF
--- a/frontend/src/lib/api/channel.svelte.ts
+++ b/frontend/src/lib/api/channel.svelte.ts
@@ -142,8 +142,8 @@ export class GameChannel {
 		});
 	}
 
-	submitAction(action: Action): void {
-		if (!this.channel) return;
+	submitAction(action: Action): number | null {
+		if (!this.channel) return null;
 
 		this.lastRejection = null;
 		this.sequenceId += 1;
@@ -155,6 +155,8 @@ export class GameChannel {
 			client_sequence_id: this.sequenceId,
 			action
 		});
+
+		return this.sequenceId;
 	}
 
 	disconnect(): void {

--- a/frontend/src/lib/stores/game.svelte.ts
+++ b/frontend/src/lib/stores/game.svelte.ts
@@ -106,7 +106,14 @@ export const gameStore = {
 
 	receiveResolution(serverPayload: GameState): void {
 		serverState = structuredClone(serverPayload);
-		optimisticState = structuredClone(serverPayload);
+		if (pendingAction !== null) {
+			// Re-apply the pending optimistic action on top of the new authoritative snapshot.
+			// state_resolved carries no client_sequence_id, so an unrelated broadcast
+			// (e.g. another player's action) must not wipe our in-flight optimistic state.
+			optimisticState = applyActionOptimistically(serverPayload, pendingAction.action);
+		} else {
+			optimisticState = structuredClone(serverPayload);
+		}
 		pendingAction = null;
 	},
 
@@ -135,6 +142,14 @@ export const gameStore = {
 		} catch (err) {
 			const msg = err instanceof Error ? err.message : 'unknown error';
 			toastStore.show(`Failed to parse game over state: ${msg}`, 'error');
+			// Transition to non-interactive game-over state even on malformed payload,
+			// using the last known authoritative state as a fallback.
+			if (serverState !== null) {
+				gameOver = {
+					winner_id: payload.winner_id,
+					finalState: structuredClone(serverState)
+				};
+			}
 			pendingAction = null;
 			return;
 		}

--- a/frontend/src/lib/stores/game.svelte.ts
+++ b/frontend/src/lib/stores/game.svelte.ts
@@ -129,7 +129,15 @@ export const gameStore = {
 	 * @param payload - Contains winner_id (optional for ties/aborts) and final_state
 	 */
 	receiveGameOver(payload: GameOverPayload): void {
-		const finalState = JSON.parse(payload.final_state) as GameState;
+		let finalState: GameState;
+		try {
+			finalState = JSON.parse(payload.final_state) as GameState;
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : 'unknown error';
+			toastStore.show(`Failed to parse game over state: ${msg}`, 'error');
+			pendingAction = null;
+			return;
+		}
 		serverState = structuredClone(finalState);
 		optimisticState = structuredClone(finalState);
 		gameOver = {

--- a/frontend/src/lib/stores/game.svelte.ts
+++ b/frontend/src/lib/stores/game.svelte.ts
@@ -1,0 +1,141 @@
+import type { Action, GameState } from '$lib/types/ditto.generated';
+import type { GameChannel } from '$lib/api/channel.svelte';
+import { toastStore } from '$lib/stores/toast.svelte';
+import type { ActionRejectedPayload, GameOverPayload } from '$lib/types/channel';
+
+/**
+ * Applies an action optimistically to a game state for immediate UI feedback.
+ * Returns a deep-cloned state that callers must treat as non-authoritative —
+ * it may be rolled back when the authoritative state arrives from the server.
+ *
+ * @param state - The current GameState to apply the action to
+ * @param action - The Action to apply (currently supports MoveEntity and EndTurn)
+ * @returns A new GameState with the action applied, or an unmodified clone if the action cannot be applied
+ */
+export function applyActionOptimistically(state: GameState, action: Action): GameState {
+	if (action === 'EndTurn' || !('MoveEntity' in action)) {
+		return structuredClone(state);
+	}
+
+	const { entity_id, from_zone, to_zone, index } = action.MoveEntity;
+
+	if (!state.zones[from_zone] || !state.zones[to_zone]) {
+		return structuredClone(state);
+	}
+
+	if (!state.zones[from_zone].entities.includes(entity_id)) {
+		return structuredClone(state);
+	}
+
+	const cloned = structuredClone(state);
+
+	cloned.zones[from_zone].entities = cloned.zones[from_zone].entities.filter(
+		(id) => id !== entity_id
+	);
+
+	if (index !== null && index !== undefined) {
+		const maxIndex = cloned.zones[to_zone].entities.length;
+		const safeIndex = Math.max(0, Math.min(index, maxIndex));
+		cloned.zones[to_zone].entities.splice(safeIndex, 0, entity_id);
+	} else {
+		cloned.zones[to_zone].entities.push(entity_id);
+	}
+
+	return cloned;
+}
+
+// Module-level reactive state
+let serverState = $state<GameState | null>(null);
+let optimisticState = $state<GameState | null>(null);
+let pendingAction = $state<{ sequenceId: number; action: Action } | null>(null);
+let gameOver = $state<{ winner_id?: string; finalState: GameState } | null>(null);
+
+// Non-reactive — set once on init, does not need reactivity
+let currentPlayerId = '';
+
+export const gameStore = {
+	get serverState(): GameState | null {
+		return serverState;
+	},
+	get optimisticState(): GameState | null {
+		return optimisticState;
+	},
+	get pendingAction(): { sequenceId: number; action: Action } | null {
+		return pendingAction;
+	},
+	get currentPlayerId(): string {
+		return currentPlayerId;
+	},
+	get gameOver(): { winner_id?: string; finalState: GameState } | null {
+		return gameOver;
+	},
+
+	initGame(initialState: GameState, playerId: string): void {
+		serverState = structuredClone(initialState);
+		optimisticState = structuredClone(initialState);
+		currentPlayerId = playerId;
+		pendingAction = null;
+		gameOver = null;
+	},
+
+	reset(): void {
+		serverState = null;
+		optimisticState = null;
+		pendingAction = null;
+		gameOver = null;
+		currentPlayerId = '';
+	},
+
+	attemptMove(action: Action, channel: GameChannel): void {
+		if (gameOver !== null) return;
+		if (optimisticState === null) return;
+		if (pendingAction !== null) {
+			toastStore.show('Action already pending - please wait', 'info');
+			return;
+		}
+
+		const sequenceId = channel.submitAction(action);
+		if (sequenceId === null) {
+			toastStore.show('Unable to send action - connection lost', 'error');
+			return;
+		}
+
+		optimisticState = applyActionOptimistically(optimisticState, action);
+		pendingAction = { sequenceId, action };
+	},
+
+	receiveResolution(serverPayload: GameState): void {
+		serverState = structuredClone(serverPayload);
+		optimisticState = structuredClone(serverPayload);
+		pendingAction = null;
+	},
+
+	receiveRejection(payload: ActionRejectedPayload): void {
+		const isStaleRejection =
+			pendingAction === null || pendingAction.sequenceId !== payload.client_sequence_id;
+		if (isStaleRejection) return;
+
+		pendingAction = null;
+		optimisticState = serverState ? structuredClone(serverState) : null;
+		const errorMessage =
+			payload.errors && payload.errors.length > 0 ? payload.errors[0].message : 'Action rejected';
+		toastStore.show(errorMessage, 'error');
+	},
+
+	/**
+	 * Handles the end-of-game signal from the server.
+	 * Deep-clones final_state to avoid shared mutable references.
+	 *
+	 * @param payload - Contains winner_id (optional for ties/aborts) and final_state
+	 */
+	receiveGameOver(payload: GameOverPayload): void {
+		const finalState = JSON.parse(payload.final_state) as GameState;
+		serverState = structuredClone(finalState);
+		optimisticState = structuredClone(finalState);
+		gameOver = {
+			winner_id: payload.winner_id,
+			finalState: structuredClone(finalState)
+		};
+		pendingAction = null;
+	}
+};

--- a/frontend/src/lib/stores/game.test.ts
+++ b/frontend/src/lib/stores/game.test.ts
@@ -1,0 +1,733 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('$lib/stores/toast.svelte', () => ({
+	toastStore: { show: vi.fn() }
+}));
+
+import { applyActionOptimistically, gameStore } from '$lib/stores/game.svelte';
+import { toastStore } from '$lib/stores/toast.svelte';
+import type { GameChannel } from '$lib/api/channel.svelte';
+import type { Action, Entity, GameState, Zone } from '$lib/types/ditto.generated';
+
+function makeEntity(id: string, ownerId = 'p1'): Entity {
+	return {
+		id,
+		owner_id: ownerId,
+		template_id: 'card',
+		properties: { health: 10 },
+		abilities: []
+	};
+}
+
+function makeZone(id: string, entities: string[], ownerId: string | null = null): Zone {
+	return {
+		id,
+		owner_id: ownerId,
+		visibility: 'Public',
+		entities
+	};
+}
+
+function makeBaseState(): GameState {
+	return {
+		entities: {},
+		zones: {},
+		event_queue: [],
+		pending_animations: [],
+		stack_order: 'Fifo',
+		state_checks: []
+	};
+}
+
+describe('applyActionOptimistically', () => {
+	it('moves entity from source zone to target zone', () => {
+		const state: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1') },
+			zones: {
+				hand: makeZone('hand', ['e1'], 'p1'),
+				battlefield: makeZone('battlefield', [], null)
+			}
+		};
+
+		const action: Action = {
+			MoveEntity: { entity_id: 'e1', from_zone: 'hand', to_zone: 'battlefield', index: null }
+		};
+
+		const result = applyActionOptimistically(state, action);
+
+		expect(result.zones['hand'].entities).toEqual([]);
+		expect(result.zones['battlefield'].entities).toEqual(['e1']);
+	});
+
+	it('preserves entity in entities map (does not delete the Entity object)', () => {
+		const entity = makeEntity('e1');
+		const state: GameState = {
+			...makeBaseState(),
+			entities: { e1: entity },
+			zones: {
+				hand: makeZone('hand', ['e1'], 'p1'),
+				graveyard: makeZone('graveyard', [], null)
+			}
+		};
+
+		const action: Action = {
+			MoveEntity: { entity_id: 'e1', from_zone: 'hand', to_zone: 'graveyard', index: null }
+		};
+
+		const result = applyActionOptimistically(state, action);
+
+		expect(result.entities['e1']).toEqual(entity);
+		expect(result.entities['e1']).toBeDefined();
+	});
+
+	it('returns unchanged state for MutateProperty action', () => {
+		const state: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1') },
+			zones: { hand: makeZone('hand', ['e1'], 'p1') }
+		};
+
+		const action: Action = {
+			MutateProperty: { target_id: 'e1', property: 'health', delta: -3 }
+		};
+
+		const result = applyActionOptimistically(state, action);
+
+		expect(result).toEqual(state);
+		expect(result).not.toBe(state);
+	});
+
+	it('returns unchanged state for SpawnEntity action', () => {
+		const state = makeBaseState();
+		const action: Action = {
+			SpawnEntity: { entity: makeEntity('new-card'), zone_id: 'hand' }
+		};
+
+		const result = applyActionOptimistically(state, action);
+
+		expect(result).toEqual(state);
+		expect(result).not.toBe(state);
+	});
+
+	it('returns unchanged state for EndTurn action', () => {
+		const state = makeBaseState();
+
+		const result = applyActionOptimistically(state, 'EndTurn');
+
+		expect(result).toEqual(state);
+		expect(result).not.toBe(state);
+	});
+
+	it('returns unchanged state when from_zone does not exist', () => {
+		const state: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1') },
+			zones: { battlefield: makeZone('battlefield', []) }
+		};
+
+		const action: Action = {
+			MoveEntity: { entity_id: 'e1', from_zone: 'hand', to_zone: 'battlefield', index: null }
+		};
+
+		const result = applyActionOptimistically(state, action);
+
+		expect(result).toEqual(state);
+		expect(result).not.toBe(state);
+	});
+
+	it('returns unchanged state when to_zone does not exist', () => {
+		const state: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1') },
+			zones: { hand: makeZone('hand', ['e1'], 'p1') }
+		};
+
+		const action: Action = {
+			MoveEntity: { entity_id: 'e1', from_zone: 'hand', to_zone: 'battlefield', index: null }
+		};
+
+		const result = applyActionOptimistically(state, action);
+
+		expect(result).toEqual(state);
+		expect(result).not.toBe(state);
+	});
+
+	it('returns unchanged state when entity not in from_zone', () => {
+		const state: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1') },
+			zones: {
+				hand: makeZone('hand', [], 'p1'),
+				battlefield: makeZone('battlefield', [])
+			}
+		};
+
+		const action: Action = {
+			MoveEntity: { entity_id: 'e1', from_zone: 'hand', to_zone: 'battlefield', index: null }
+		};
+
+		const result = applyActionOptimistically(state, action);
+
+		expect(result).toEqual(state);
+		expect(result).not.toBe(state);
+	});
+
+	it('does not mutate the original state (immutability check)', () => {
+		const state: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1') },
+			zones: {
+				hand: makeZone('hand', ['e1'], 'p1'),
+				battlefield: makeZone('battlefield', [])
+			}
+		};
+
+		const before = JSON.parse(JSON.stringify(state));
+
+		const action: Action = {
+			MoveEntity: { entity_id: 'e1', from_zone: 'hand', to_zone: 'battlefield', index: null }
+		};
+
+		const result = applyActionOptimistically(state, action);
+
+		expect(state).toEqual(before);
+		expect(result).not.toBe(state);
+	});
+
+	it('inserts at index position when index is provided', () => {
+		const state: GameState = {
+			...makeBaseState(),
+			entities: {
+				e1: makeEntity('e1'),
+				e2: makeEntity('e2'),
+				e3: makeEntity('e3')
+			},
+			zones: {
+				hand: makeZone('hand', ['e1'], 'p1'),
+				battlefield: makeZone('battlefield', ['e2', 'e3'])
+			}
+		};
+
+		const action: Action = {
+			MoveEntity: { entity_id: 'e1', from_zone: 'hand', to_zone: 'battlefield', index: 1 }
+		};
+
+		const result = applyActionOptimistically(state, action);
+
+		expect(result.zones['battlefield'].entities).toEqual(['e2', 'e1', 'e3']);
+	});
+});
+
+describe('initGame', () => {
+	beforeEach(() => {
+		gameStore.reset();
+	});
+
+	it('sets serverState and optimisticState from provided state', () => {
+		const state: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1') },
+			zones: { hand: makeZone('hand', ['e1'], 'p1') }
+		};
+
+		gameStore.initGame(state, 'p1');
+
+		expect(gameStore.serverState).toEqual(state);
+		expect(gameStore.serverState).not.toBe(state);
+		expect(gameStore.optimisticState).toEqual(state);
+		expect(gameStore.optimisticState).not.toBe(state);
+	});
+
+	it('sets currentPlayerId', () => {
+		const state = makeBaseState();
+		gameStore.initGame(state, 'player-123');
+
+		expect(gameStore.currentPlayerId).toBe('player-123');
+	});
+
+	it('clears pendingAction and gameOver', () => {
+		const state = makeBaseState();
+		gameStore.initGame(state, 'p1');
+
+		expect(gameStore.pendingAction).toBeNull();
+		expect(gameStore.gameOver).toBeNull();
+	});
+
+	it('called twice overwrites cleanly', () => {
+		const stateA: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1') },
+			zones: { hand: makeZone('hand', ['e1'], 'p1') }
+		};
+
+		const stateB: GameState = {
+			...makeBaseState(),
+			entities: { e2: makeEntity('e2') },
+			zones: { battlefield: makeZone('battlefield', ['e2'], null) }
+		};
+
+		gameStore.initGame(stateA, 'p1');
+		gameStore.initGame(stateB, 'p2');
+
+		expect(gameStore.serverState).toEqual(stateB);
+		expect(gameStore.optimisticState).toEqual(stateB);
+		expect(gameStore.currentPlayerId).toBe('p2');
+	});
+});
+
+describe('gameStore getters', () => {
+	beforeEach(() => {
+		gameStore.reset();
+	});
+
+	it('return null before init', () => {
+		expect(gameStore.serverState).toBeNull();
+		expect(gameStore.optimisticState).toBeNull();
+		expect(gameStore.pendingAction).toBeNull();
+		expect(gameStore.gameOver).toBeNull();
+		expect(gameStore.currentPlayerId).toBe('');
+	});
+});
+
+describe('reset', () => {
+	beforeEach(() => {
+		gameStore.reset();
+	});
+
+	it('clears all state', () => {
+		const state: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1') },
+			zones: { hand: makeZone('hand', ['e1'], 'p1') }
+		};
+
+		gameStore.initGame(state, 'p1');
+		gameStore.reset();
+
+		expect(gameStore.serverState).toBeNull();
+		expect(gameStore.optimisticState).toBeNull();
+		expect(gameStore.pendingAction).toBeNull();
+		expect(gameStore.gameOver).toBeNull();
+		expect(gameStore.currentPlayerId).toBe('');
+	});
+});
+
+describe('attemptMove', () => {
+	const mockChannel = {
+		submitAction: vi.fn(),
+		currentSequenceId: 0
+	} as unknown as GameChannel;
+
+	beforeEach(() => {
+		gameStore.reset();
+		vi.clearAllMocks();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(mockChannel as any).currentSequenceId = 0;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(mockChannel.submitAction as any).mockImplementation(() => {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			(mockChannel as any).currentSequenceId += 1;
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			return (mockChannel as any).currentSequenceId;
+		});
+	});
+
+	it('applies optimistic MoveEntity to optimisticState', () => {
+		const state: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1') },
+			zones: {
+				hand: makeZone('hand', ['e1'], 'p1'),
+				battlefield: makeZone('battlefield', [], null)
+			}
+		};
+
+		const action: Action = {
+			MoveEntity: { entity_id: 'e1', from_zone: 'hand', to_zone: 'battlefield', index: null }
+		};
+
+		gameStore.initGame(state, 'p1');
+		gameStore.attemptMove(action, mockChannel);
+
+		expect(gameStore.optimisticState?.zones['battlefield'].entities).toContain('e1');
+		expect(gameStore.optimisticState?.zones['hand'].entities).not.toContain('e1');
+	});
+
+	it('does not modify serverState', () => {
+		const state: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1') },
+			zones: {
+				hand: makeZone('hand', ['e1'], 'p1'),
+				battlefield: makeZone('battlefield', [], null)
+			}
+		};
+
+		const action: Action = {
+			MoveEntity: { entity_id: 'e1', from_zone: 'hand', to_zone: 'battlefield', index: null }
+		};
+
+		gameStore.initGame(state, 'p1');
+		gameStore.attemptMove(action, mockChannel);
+
+		expect(gameStore.serverState?.zones['hand'].entities).toContain('e1');
+	});
+
+	it('sets pendingAction with correct sequenceId', () => {
+		const state: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1') },
+			zones: {
+				hand: makeZone('hand', ['e1'], 'p1'),
+				battlefield: makeZone('battlefield', [], null)
+			}
+		};
+
+		const action: Action = {
+			MoveEntity: { entity_id: 'e1', from_zone: 'hand', to_zone: 'battlefield', index: null }
+		};
+
+		gameStore.initGame(state, 'p1');
+		gameStore.attemptMove(action, mockChannel);
+
+		expect(gameStore.pendingAction).not.toBeNull();
+		expect(gameStore.pendingAction?.sequenceId).toBe(1);
+		expect(gameStore.pendingAction?.action).toEqual(action);
+	});
+
+	it('calls channel.submitAction with the action', () => {
+		const state: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1') },
+			zones: {
+				hand: makeZone('hand', ['e1'], 'p1'),
+				battlefield: makeZone('battlefield', [], null)
+			}
+		};
+
+		const action: Action = {
+			MoveEntity: { entity_id: 'e1', from_zone: 'hand', to_zone: 'battlefield', index: null }
+		};
+
+		gameStore.initGame(state, 'p1');
+		gameStore.attemptMove(action, mockChannel);
+
+		expect(mockChannel.submitAction).toHaveBeenCalledTimes(1);
+		expect(mockChannel.submitAction).toHaveBeenCalledWith(action);
+	});
+
+	it.todo('no-ops when gameOver is set');
+
+	it('no-ops when optimisticState is null (not initialized)', () => {
+		const action: Action = {
+			MoveEntity: { entity_id: 'e1', from_zone: 'hand', to_zone: 'battlefield', index: null }
+		};
+
+		gameStore.attemptMove(action, mockChannel);
+
+		expect(mockChannel.submitAction).not.toHaveBeenCalled();
+		expect(gameStore.optimisticState).toBeNull();
+	});
+
+	it('handles non-MoveEntity actions (applies optimistically but returns unchanged state)', () => {
+		const state: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1') },
+			zones: { hand: makeZone('hand', ['e1'], 'p1') }
+		};
+
+		gameStore.initGame(state, 'p1');
+		gameStore.attemptMove('EndTurn', mockChannel);
+
+		expect(mockChannel.submitAction).toHaveBeenCalledWith('EndTurn');
+		expect(gameStore.optimisticState).toEqual(gameStore.serverState);
+		expect(gameStore.pendingAction).not.toBeNull();
+		expect(gameStore.pendingAction?.sequenceId).toBe(1);
+		expect(gameStore.pendingAction?.action).toEqual('EndTurn');
+	});
+
+	it('no-ops when pendingAction already exists (blocks concurrent moves)', () => {
+		const state: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1') },
+			zones: {
+				hand: makeZone('hand', ['e1'], 'p1'),
+				battlefield: makeZone('battlefield', [], null)
+			}
+		};
+
+		const action1: Action = {
+			MoveEntity: { entity_id: 'e1', from_zone: 'hand', to_zone: 'battlefield', index: null }
+		};
+		const action2: Action = {
+			MoveEntity: { entity_id: 'e1', from_zone: 'battlefield', to_zone: 'hand', index: null }
+		};
+
+		gameStore.initGame(state, 'p1');
+		gameStore.attemptMove(action1, mockChannel);
+		const firstPending = gameStore.pendingAction;
+
+		gameStore.attemptMove(action2, mockChannel);
+
+		expect(gameStore.pendingAction).toEqual(firstPending);
+		expect(gameStore.pendingAction?.action).toEqual(action1);
+		expect(mockChannel.submitAction).toHaveBeenCalledTimes(1);
+		expect(toastStore.show).toHaveBeenCalledWith('Action already pending - please wait', 'info');
+	});
+
+	it('no-ops when submitAction returns null (channel not available)', () => {
+		const state: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1') },
+			zones: {
+				hand: makeZone('hand', ['e1'], 'p1'),
+				battlefield: makeZone('battlefield', [], null)
+			}
+		};
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(mockChannel.submitAction as any).mockReturnValue(null);
+
+		const action: Action = {
+			MoveEntity: { entity_id: 'e1', from_zone: 'hand', to_zone: 'battlefield', index: null }
+		};
+
+		gameStore.initGame(state, 'p1');
+		gameStore.attemptMove(action, mockChannel);
+
+		expect(gameStore.optimisticState).toEqual(state);
+		expect(gameStore.pendingAction).toBeNull();
+	});
+});
+
+describe('receiveResolution', () => {
+	beforeEach(() => {
+		gameStore.reset();
+	});
+
+	it('replaces both serverState and optimisticState with server payload', () => {
+		const stateA: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1') },
+			zones: { hand: makeZone('hand', ['e1'], 'p1') }
+		};
+
+		const stateB: GameState = {
+			...makeBaseState(),
+			entities: { e2: makeEntity('e2') },
+			zones: { battlefield: makeZone('battlefield', ['e2'], null) }
+		};
+
+		gameStore.initGame(stateA, 'p1');
+		gameStore.receiveResolution(stateB);
+
+		expect(gameStore.serverState).toEqual(stateB);
+		expect(gameStore.optimisticState).toEqual(stateB);
+	});
+
+	it('clears pendingAction', () => {
+		const state = makeBaseState();
+
+		gameStore.initGame(state, 'p1');
+		gameStore.receiveResolution(state);
+
+		expect(gameStore.pendingAction).toBeNull();
+	});
+
+	it('works even when no pendingAction exists', () => {
+		const state = makeBaseState();
+
+		gameStore.initGame(state, 'p1');
+
+		expect(() => gameStore.receiveResolution(state)).not.toThrow();
+		expect(gameStore.optimisticState).toEqual(state);
+	});
+});
+
+describe('receiveRejection', () => {
+	beforeEach(() => {
+		gameStore.reset();
+		vi.clearAllMocks();
+	});
+
+	it('rolls optimisticState back to serverState', () => {
+		const stateA: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1') },
+			zones: { hand: makeZone('hand', ['e1'], 'p1') }
+		};
+
+		gameStore.initGame(stateA, 'p1');
+		gameStore.receiveRejection({
+			client_sequence_id: 1,
+			errors: [{ message: 'Invalid move', code: 'invalid_move' }]
+		});
+
+		expect(gameStore.optimisticState).toEqual(gameStore.serverState);
+	});
+
+	it('clears pendingAction', () => {
+		const state = makeBaseState();
+
+		gameStore.initGame(state, 'p1');
+		gameStore.receiveRejection({
+			client_sequence_id: 1,
+			errors: [{ message: 'Invalid move', code: 'invalid_move' }]
+		});
+
+		expect(gameStore.pendingAction).toBeNull();
+	});
+
+	it('calls toastStore.show with first error message', () => {
+		const state: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1') },
+			zones: {
+				hand: makeZone('hand', ['e1'], 'p1'),
+				battlefield: makeZone('battlefield', [], null)
+			}
+		};
+
+		gameStore.initGame(state, 'p1');
+
+		const mockChannel = {
+			submitAction: vi.fn().mockReturnValue(1),
+			currentSequenceId: 1
+		} as unknown as GameChannel;
+		const action: Action = {
+			MoveEntity: { entity_id: 'e1', from_zone: 'hand', to_zone: 'battlefield', index: null }
+		};
+		gameStore.attemptMove(action, mockChannel);
+
+		gameStore.receiveRejection({
+			client_sequence_id: 1,
+			errors: [{ message: 'Invalid move', code: 'invalid_move' }]
+		});
+
+		expect(toastStore.show).toHaveBeenCalledWith('Invalid move', 'error');
+	});
+
+	it('handles empty errors array gracefully', () => {
+		const state: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1') },
+			zones: {
+				hand: makeZone('hand', ['e1'], 'p1'),
+				battlefield: makeZone('battlefield', [], null)
+			}
+		};
+		gameStore.initGame(state, 'p1');
+
+		const mockChannel = {
+			submitAction: vi.fn().mockReturnValue(1),
+			currentSequenceId: 1
+		} as unknown as GameChannel;
+		const action: Action = {
+			MoveEntity: { entity_id: 'e1', from_zone: 'hand', to_zone: 'battlefield', index: null }
+		};
+		gameStore.attemptMove(action, mockChannel);
+
+		gameStore.receiveRejection({
+			client_sequence_id: 1,
+			errors: []
+		});
+
+		expect(toastStore.show).toHaveBeenCalledWith('Action rejected', 'error');
+	});
+
+	it('ignores rejection with mismatched sequenceId (stale rejection)', () => {
+		const stateA: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1') },
+			zones: {
+				hand: makeZone('hand', ['e1'], 'p1'),
+				battlefield: makeZone('battlefield', [], null)
+			}
+		};
+
+		const staleSequenceId = 2;
+
+		gameStore.initGame(stateA, 'p1');
+
+		const mockChannel = {
+			submitAction: vi.fn().mockReturnValue(5),
+			currentSequenceId: 5
+		} as unknown as GameChannel;
+		const action: Action = {
+			MoveEntity: { entity_id: 'e1', from_zone: 'hand', to_zone: 'battlefield', index: null }
+		};
+		gameStore.attemptMove(action, mockChannel);
+
+		const expectedPending = gameStore.pendingAction;
+		const expectedOptimistic = gameStore.optimisticState;
+
+		gameStore.receiveRejection({
+			client_sequence_id: staleSequenceId,
+			errors: [{ message: 'Old action failed', code: 'old_error' }]
+		});
+
+		expect(gameStore.pendingAction).toEqual(expectedPending);
+		expect(gameStore.optimisticState).toEqual(expectedOptimistic);
+		expect(toastStore.show).not.toHaveBeenCalled();
+	});
+
+	it('ignores rejection when no pendingAction exists', () => {
+		const state = makeBaseState();
+		gameStore.initGame(state, 'p1');
+
+		gameStore.receiveRejection({
+			client_sequence_id: 1,
+			errors: [{ message: 'Unexpected rejection', code: 'unexpected' }]
+		});
+
+		expect(toastStore.show).not.toHaveBeenCalled();
+	});
+});
+
+describe('receiveGameOver', () => {
+	beforeEach(() => {
+		gameStore.reset();
+	});
+
+	it('sets gameOver with winner_id and finalState', () => {
+		const initial = makeBaseState();
+		const finalState: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1') },
+			zones: { graveyard: makeZone('graveyard', ['e1'], null) }
+		};
+
+		gameStore.initGame(initial, 'p1');
+		gameStore.receiveGameOver({ winner_id: 'p1', final_state: JSON.stringify(finalState) });
+
+		expect(gameStore.gameOver).not.toBeNull();
+		expect(gameStore.gameOver?.winner_id).toBe('p1');
+		expect(gameStore.gameOver?.finalState).toEqual(finalState);
+	});
+
+	it('updates both serverState and optimisticState', () => {
+		const initial = makeBaseState();
+		const finalState: GameState = {
+			...makeBaseState(),
+			entities: { e2: makeEntity('e2') },
+			zones: { battlefield: makeZone('battlefield', ['e2'], null) }
+		};
+
+		gameStore.initGame(initial, 'p1');
+		gameStore.receiveGameOver({ winner_id: 'p2', final_state: JSON.stringify(finalState) });
+
+		expect(gameStore.serverState).toEqual(finalState);
+		expect(gameStore.optimisticState).toEqual(finalState);
+	});
+
+	it('clears pendingAction', () => {
+		const initial = makeBaseState();
+		const finalState = makeBaseState();
+
+		gameStore.initGame(initial, 'p1');
+		gameStore.receiveGameOver({ winner_id: 'p1', final_state: JSON.stringify(finalState) });
+
+		expect(gameStore.pendingAction).toBeNull();
+	});
+});

--- a/frontend/src/lib/stores/game.test.ts
+++ b/frontend/src/lib/stores/game.test.ts
@@ -419,7 +419,30 @@ describe('attemptMove', () => {
 		expect(mockChannel.submitAction).toHaveBeenCalledWith(action);
 	});
 
-	it.todo('no-ops when gameOver is set');
+	it('no-ops when gameOver is set', () => {
+		const initial: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1') },
+			zones: {
+				hand: makeZone('hand', ['e1'], 'p1'),
+				battlefield: makeZone('battlefield', [], null)
+			}
+		};
+		const finalState = makeBaseState();
+		const action: Action = {
+			MoveEntity: { entity_id: 'e1', from_zone: 'hand', to_zone: 'battlefield', index: null }
+		};
+
+		gameStore.initGame(initial, 'p1');
+		gameStore.receiveGameOver({ winner_id: 'p1', final_state: JSON.stringify(finalState) });
+
+		const optimisticBefore = gameStore.optimisticState;
+		gameStore.attemptMove(action, mockChannel);
+
+		expect(mockChannel.submitAction).not.toHaveBeenCalled();
+		expect(gameStore.optimisticState).toBe(optimisticBefore);
+		expect(gameStore.pendingAction).toBeNull();
+	});
 
 	it('no-ops when optimisticState is null (not initialized)', () => {
 		const action: Action = {

--- a/frontend/src/lib/stores/game.test.ts
+++ b/frontend/src/lib/stores/game.test.ts
@@ -527,8 +527,23 @@ describe('attemptMove', () => {
 });
 
 describe('receiveResolution', () => {
+	const mockChannel = {
+		submitAction: vi.fn(),
+		currentSequenceId: 0
+	} as unknown as GameChannel;
+
 	beforeEach(() => {
 		gameStore.reset();
+		vi.clearAllMocks();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(mockChannel as any).currentSequenceId = 0;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(mockChannel.submitAction as any).mockImplementation(() => {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			(mockChannel as any).currentSequenceId += 1;
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			return (mockChannel as any).currentSequenceId;
+		});
 	});
 
 	it('replaces both serverState and optimisticState with server payload', () => {
@@ -567,6 +582,75 @@ describe('receiveResolution', () => {
 
 		expect(() => gameStore.receiveResolution(state)).not.toThrow();
 		expect(gameStore.optimisticState).toEqual(state);
+	});
+
+	it('re-applies pending optimistic action on top of server snapshot when pending action exists', () => {
+		const stateA: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1'), e2: makeEntity('e2', 'p2') },
+			zones: {
+				hand: makeZone('hand', ['e1'], 'p1'),
+				battlefield: makeZone('battlefield', [], null)
+			}
+		};
+
+		// Incoming snapshot does not yet reflect our pending move (simulating another player's action)
+		const stateB: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1'), e2: makeEntity('e2', 'p2') },
+			zones: {
+				hand: makeZone('hand', ['e1'], 'p1'),
+				battlefield: makeZone('battlefield', ['e2'], null)
+			}
+		};
+
+		const action: Action = {
+			MoveEntity: { entity_id: 'e1', from_zone: 'hand', to_zone: 'battlefield', index: null }
+		};
+
+		gameStore.initGame(stateA, 'p1');
+		gameStore.attemptMove(action, mockChannel);
+		gameStore.receiveResolution(stateB);
+
+		// authoritative state reflects the incoming snapshot
+		expect(gameStore.serverState).toEqual(stateB);
+		// optimistic state re-applies our pending move on top of the snapshot
+		expect(gameStore.optimisticState?.zones['battlefield'].entities).toContain('e1');
+		expect(gameStore.optimisticState?.zones['hand'].entities).not.toContain('e1');
+		// pendingAction is still cleared
+		expect(gameStore.pendingAction).toBeNull();
+	});
+
+	it('clears pendingAction even when it was set before receiveResolution', () => {
+		const state: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1') },
+			zones: {
+				hand: makeZone('hand', ['e1'], 'p1'),
+				battlefield: makeZone('battlefield', [], null)
+			}
+		};
+
+		const action: Action = {
+			MoveEntity: { entity_id: 'e1', from_zone: 'hand', to_zone: 'battlefield', index: null }
+		};
+
+		const resolvedState: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1') },
+			zones: {
+				hand: makeZone('hand', [], 'p1'),
+				battlefield: makeZone('battlefield', ['e1'], null)
+			}
+		};
+
+		gameStore.initGame(state, 'p1');
+		gameStore.attemptMove(action, mockChannel);
+		expect(gameStore.pendingAction).not.toBeNull();
+
+		gameStore.receiveResolution(resolvedState);
+
+		expect(gameStore.pendingAction).toBeNull();
 	});
 });
 
@@ -713,6 +797,7 @@ describe('receiveRejection', () => {
 describe('receiveGameOver', () => {
 	beforeEach(() => {
 		gameStore.reset();
+		vi.clearAllMocks();
 	});
 
 	it('sets gameOver with winner_id and finalState', () => {
@@ -753,6 +838,26 @@ describe('receiveGameOver', () => {
 		gameStore.initGame(initial, 'p1');
 		gameStore.receiveGameOver({ winner_id: 'p1', final_state: JSON.stringify(finalState) });
 
+		expect(gameStore.pendingAction).toBeNull();
+	});
+
+	it('sets gameOver with serverState fallback when final_state JSON is malformed', () => {
+		const initial: GameState = {
+			...makeBaseState(),
+			entities: { e1: makeEntity('e1') },
+			zones: { hand: makeZone('hand', ['e1'], 'p1') }
+		};
+
+		gameStore.initGame(initial, 'p1');
+		gameStore.receiveGameOver({ winner_id: 'p1', final_state: 'not valid json' });
+
+		expect(toastStore.show).toHaveBeenCalledWith(
+			expect.stringContaining('Failed to parse game over state'),
+			'error'
+		);
+		expect(gameStore.gameOver).not.toBeNull();
+		expect(gameStore.gameOver?.winner_id).toBe('p1');
+		expect(gameStore.gameOver?.finalState).toEqual(initial);
 		expect(gameStore.pendingAction).toBeNull();
 	});
 });

--- a/frontend/src/lib/types/channel.ts
+++ b/frontend/src/lib/types/channel.ts
@@ -57,3 +57,12 @@ export type ChannelError = {
 export type ChannelErrorEnvelope = {
 	errors: ChannelError[];
 };
+
+/**
+ * Server broadcast received via `channel.on("game_over", ...)`.
+ * `final_state` is a JSON **string** — call `JSON.parse()` to get a `GameState`.
+ */
+export type GameOverPayload = {
+	winner_id?: string;
+	final_state: string;
+};

--- a/frontend/src/routes/(dashboard)/dashboard/games/[id]/playtest/+page.svelte
+++ b/frontend/src/routes/(dashboard)/dashboard/games/[id]/playtest/+page.svelte
@@ -12,6 +12,7 @@
 	import type { Action } from '$lib/types/ditto.generated';
 	import GameBoard from '$lib/components/game/GameBoard.svelte';
 	import { getContext, onMount } from 'svelte';
+	import { gameStore } from '$lib/stores/game.svelte';
 
 	const getGame = getContext<() => Game | null>('game');
 	let game = $derived(getGame());
@@ -22,7 +23,7 @@
 	let channel = $state<GameChannel | null>(null);
 
 	let validDropTargets = $state<string[]>([]);
-	let gameOver = $state<{ winner_id?: string } | null>(null);
+	let gameOver = $derived(gameStore.gameOver);
 
 	let loadedGameId: string | null = null;
 
@@ -53,7 +54,10 @@
 	async function startPlaytest() {
 		if (!game || selectedDeckId === null || !authStore.token || !authStore.currentUser) return;
 
-		const roomId = `solo_${authStore.currentUser.id}_${game.id}`;
+		const localUser = authStore.currentUser;
+		const localGame = game;
+		const localDeckId = selectedDeckId;
+		const roomId = `solo_${localUser.id}_${localGame.id}`;
 		let ch: GameChannel | null = null;
 
 		try {
@@ -62,29 +66,46 @@
 			channel = ch;
 
 			await ch.connect(roomId, {
-				game_id: game.id,
-				deck_id: selectedDeckId
+				game_id: localGame.id,
+				deck_id: localDeckId
 			});
+
+			if (channel !== ch || !ch.gameState || !authStore.currentUser) {
+				ch.disconnect();
+				if (channel === ch) channel = null;
+				return;
+			}
+
+			gameStore.initGame(ch.gameState, localUser.id);
 		} catch {
 			ch?.disconnect();
-			channel = null;
+			if (channel === ch) channel = null;
 			toastStore.show('Failed to connect to game channel.');
 		}
 	}
 
 	function endTurn() {
-		channel?.submitAction('EndTurn');
+		if (channel) gameStore.attemptMove('EndTurn', channel);
 	}
 
 	function disconnectChannel() {
 		channel?.disconnect();
 		channel = null;
+		gameStore.reset();
 	}
 
 	async function handleDrop(entityId: string, toZone: string) {
 		if (!gameState || !channel) return;
+		if (gameStore.pendingAction !== null) {
+			toastStore.show('Action pending - please wait', 'info');
+			return;
+		}
 
-		const fromZone = findEntityZone(gameState, entityId);
+		const capturedState = gameState;
+		const capturedChannel = channel;
+		const capturedPlayerId = currentPlayerId;
+
+		const fromZone = findEntityZone(capturedState, entityId);
 		if (!fromZone) return;
 
 		const action: Action = {
@@ -97,15 +118,22 @@
 		};
 
 		try {
-			const publicState = stripPrivateState(gameState, currentPlayerId);
+			const publicState = stripPrivateState(capturedState, capturedPlayerId);
 			const result = await validateMove(publicState, action);
+
+			const stateChanged = gameState !== capturedState || channel !== capturedChannel;
+			const entityMoved = findEntityZone(gameState ?? capturedState, entityId) !== fromZone;
+			if (stateChanged || entityMoved) {
+				toastStore.show('Game state changed during validation. Please try again.');
+				return;
+			}
 
 			if (!result.ok) {
 				toastStore.show(result.message);
 				return;
 			}
 
-			channel.submitAction(action);
+			gameStore.attemptMove(action, capturedChannel);
 		} catch {
 			toastStore.show('Validation failed. Please try again.');
 		}
@@ -115,11 +143,26 @@
 		const ch = channel;
 		return () => {
 			ch?.disconnect();
+			gameStore.reset();
 		};
 	});
 
+	$effect(() => {
+		const ch = channel;
+		if (!ch?.gameState) return;
+		// Skip if state hasn't changed (already handled by initGame)
+		if (gameStore.serverState !== null) return;
+		gameStore.receiveResolution(ch.gameState);
+	});
+
+	$effect(() => {
+		const rejection = channel?.lastRejection;
+		if (!rejection) return;
+		gameStore.receiveRejection(rejection);
+	});
+
 	let connectionStatus = $derived<ConnectionStatus>(channel?.connectionStatus ?? 'disconnected');
-	let gameState = $derived(channel?.gameState ?? null);
+	let gameState = $derived(gameStore.optimisticState);
 	let lastRejection = $derived(channel?.lastRejection ?? null);
 	let errors = $derived(channel?.errors ?? []);
 
@@ -134,6 +177,8 @@
 	$effect(() => {
 		if (gameState) {
 			validDropTargets = Object.keys(gameState.zones);
+		} else {
+			validDropTargets = [];
 		}
 	});
 

--- a/frontend/src/routes/(dashboard)/dashboard/games/[id]/playtest/+page.svelte
+++ b/frontend/src/routes/(dashboard)/dashboard/games/[id]/playtest/+page.svelte
@@ -97,6 +97,7 @@
 	function handleReturnToDashboard() {
 		channel?.disconnect();
 		channel = null;
+		gameStore.reset();
 		goto('/dashboard');
 	}
 
@@ -156,8 +157,6 @@
 	$effect(() => {
 		const ch = channel;
 		if (!ch?.gameState) return;
-		// Skip if state hasn't changed (already handled by initGame)
-		if (gameStore.serverState !== null) return;
 		gameStore.receiveResolution(ch.gameState);
 	});
 
@@ -167,11 +166,17 @@
 		gameStore.receiveRejection(rejection);
 	});
 
+	$effect(() => {
+		const over = channel?.gameOver;
+		if (!over) return;
+		gameStore.receiveGameOver(over);
+	});
+
 	let connectionStatus = $derived<ConnectionStatus>(channel?.connectionStatus ?? 'disconnected');
 	let gameState = $derived(gameStore.optimisticState);
 	let lastRejection = $derived(channel?.lastRejection ?? null);
 	let errors = $derived(channel?.errors ?? []);
-	let gameOver = $derived(channel?.gameOver ?? null);
+	let gameOver = $derived(gameStore.gameOver);
 
 	const currentPlayerId = $derived(authStore.currentUser?.id ?? '');
 


### PR DESCRIPTION
This pull request introduces a new optimistic update system for in-progress game actions in the playtest UI. The core idea is to immediately reflect user actions in the UI (such as moving an entity or ending a turn) before receiving server confirmation, providing a more responsive experience. The changes include a new `gameStore` for managing optimistic and authoritative game state, integration of this store into the playtest page, and updates to types and action handling.

The most important changes are:

**Optimistic State Management**

* Introduced `gameStore` in `game.svelte.ts` to manage both the authoritative server state and an optimistic state, as well as pending actions and game-over status. This store provides methods for initializing, resetting, and updating state based on user actions and server responses.
* Added `applyActionOptimistically` to allow immediate, local application of game actions (currently supports `MoveEntity` and `EndTurn`), enabling UI updates before server confirmation.

**Playtest Page Integration**

* Updated `+page.svelte` to use `gameStore` for all game state, action, and game-over handling, replacing direct use of `GameChannel` state. This includes handling optimistic updates, rejections, and server resolutions, as well as updating UI bindings. ([frontend/src/routes/(dashboard)/dashboard/games/[id]/playtest/+page.svelteR16](diffhunk://#diff-3d423f9dbb7cc47a71dbbe96707e5c51b2da185708f0495d4422a2308850597cR16), [frontend/src/routes/(dashboard)/dashboard/games/[id]/playtest/+page.svelteL65-R94](diffhunk://#diff-3d423f9dbb7cc47a71dbbe96707e5c51b2da185708f0495d4422a2308850597cL65-R94), [frontend/src/routes/(dashboard)/dashboard/games/[id]/playtest/+page.svelteR105-R114](diffhunk://#diff-3d423f9dbb7cc47a71dbbe96707e5c51b2da185708f0495d4422a2308850597cR105-R114), [frontend/src/routes/(dashboard)/dashboard/games/[id]/playtest/+page.svelteL106-R142](diffhunk://#diff-3d423f9dbb7cc47a71dbbe96707e5c51b2da185708f0495d4422a2308850597cL106-R142), [frontend/src/routes/(dashboard)/dashboard/games/[id]/playtest/+page.svelteR152-R171](diffhunk://#diff-3d423f9dbb7cc47a71dbbe96707e5c51b2da185708f0495d4422a2308850597cR152-R171), [frontend/src/routes/(dashboard)/dashboard/games/[id]/playtest/+page.svelteR187-R188](diffhunk://#diff-3d423f9dbb7cc47a71dbbe96707e5c51b2da185708f0495d4422a2308850597cR187-R188))
* Enhanced action submission logic to prevent duplicate/pending actions and to show appropriate user feedback via toasts. ([frontend/src/routes/(dashboard)/dashboard/games/[id]/playtest/+page.svelteR105-R114](diffhunk://#diff-3d423f9dbb7cc47a71dbbe96707e5c51b2da185708f0495d4422a2308850597cR105-R114), [frontend/src/routes/(dashboard)/dashboard/games/[id]/playtest/+page.svelteL106-R142](diffhunk://#diff-3d423f9dbb7cc47a71dbbe96707e5c51b2da185708f0495d4422a2308850597cL106-R142))

**API and Type Updates**

* Modified `GameChannel.submitAction` to return the sequence ID of the submitted action, or `null` if the channel is unavailable, enabling tracking of pending actions. [[1]](diffhunk://#diff-8d03421b0a1c80298c75d1edc7ef9e97a3aa7a811d04f5fb1ae9e84157ed9e77L151-R152) [[2]](diffhunk://#diff-8d03421b0a1c80298c75d1edc7ef9e97a3aa7a811d04f5fb1ae9e84157ed9e77R164-R165)
* Updated the `GameOverPayload` type to clarify that `final_state` is a JSON string and that `winner_id` is optional.

These changes collectively improve the responsiveness and reliability of the playtest UI by enabling immediate feedback for game actions and robust handling of server responses and errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optimistic game store with immediate move previews, in-flight action tracking, and game-over final-state capture (including parsed final state).
  * Playtest UI now uses the optimistic store for submissions, validation, drift detection, and cleanup.

* **Bug Fixes**
  * Handles failed/absent action submissions (returns null), prevents duplicate submissions, blocks drops while pending, and improves rejection rollback with error toasts.

* **Tests**
  * Added unit tests for optimistic updates, submission flows, reconciliation, rejections, and game-over handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->